### PR TITLE
adjust two more manifests for local install

### DIFF
--- a/install-bibbox-local.sh
+++ b/install-bibbox-local.sh
@@ -62,6 +62,8 @@ sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/mani
 sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config_packages.pp
 sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config_files.pp
 sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config_services.pp
+sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config.pp
+sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/init.pp
 
 
 /opt/puppetlabs/bin/puppet apply --modulepath=/etc/puppetlabs/code/modules:/opt/bibbox-install/modules-local  /opt/bibbox-install/environments/local/manifests/config_ubuntu.pp

--- a/install-bibbox-local.sh
+++ b/install-bibbox-local.sh
@@ -62,8 +62,8 @@ sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/mani
 sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config_packages.pp
 sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config_files.pp
 sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config_services.pp
-sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/config.pp
-sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/local/manifests/init.pp
+sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/modules/vmbuilder/manifests/init.pp
+sed -i "s/eb3kit.bibbox.org/$url/g"  /opt/bibbox-install/environments/production/manifests/config.pp
 
 
 /opt/puppetlabs/bin/puppet apply --modulepath=/etc/puppetlabs/code/modules:/opt/bibbox-install/modules-local  /opt/bibbox-install/environments/local/manifests/config_ubuntu.pp


### PR DESCRIPTION
I needed to replace "eb3kit.bibbox.org" in two more manifests (config.pp, init.pp) to get the local installation to display the application store and instances.